### PR TITLE
Fixing ArgumentError in instance_eval for ruby 1.9.2

### DIFF
--- a/lib/shotgun/loader.rb
+++ b/lib/shotgun/loader.rb
@@ -11,7 +11,7 @@ module Shotgun
 
     def initialize(rackup_file, &block)
       @rackup_file = rackup_file
-      @config = block || lambda { }
+      @config = block || Proc.new { }
     end
 
     def call(env)


### PR DESCRIPTION
Hi,

The tests fail on ruby 1.9.2 for instance_eval with ArgumentError.
Haven't test it on other ruby version but expect them to work correctly.
