### PR TITLE
Convert Readme to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-                                    Shotgun
+# Shotgun
 
 This is an automatic reloading version of the rackup command that's shipped with
 Rack. It can be used as an alternative to the complex reloading logic provided
@@ -16,28 +16,37 @@ Usage
 
 Installation:
 
-    gem install shotgun
+```shell
+  gem install shotgun
+```
 
 Starting a server with a rackup file:
 
-    shotgun config.ru
-
+```shell
+  shotgun config.ru
+```
 Using Thin and starting on port 6000 instead of 9393 (default):
 
-    shotgun --server=thin --port=6000 config.ru
-
+```shell
+  shotgun --server=thin --port=6000 config.ru
+```
 Running Sinatra apps:
 
-    shotgun hello.rb
+
+```shell
+  shotgun hello.rb
+```
 
 See 'shotgun --help' for more advanced usage.
 
 Links
 -----
 
-Shotgun:       http://github.com/rtomayko/shotgun
-Rack:          http://rack.rubyforge.org/
-Sinatra:       http://www.sinatrarb.com/
+[Shotgun](http://github.com/rtomayko/shotgun)
+
+[Rack](http://rack.rubyforge.org/)
+
+[Sinatra](http://www.sinatrarb.com/)
 
 The reloading system in Ian Bicking's webware framework served as inspiration
 for the approach taken in Shotgun. Ian lays down the pros and cons of this


### PR DESCRIPTION
I ported the existing readme to markdown, you can check out the formatting result here: https://github.com/schneems/shotgun . Makes the page a bit more readable.

Also wanted to mention that the last link on the page to Ian's article is broken. I didn't want to change any content, so I just left it there. 