### PR TITLE
Calling close on response body inside child process

### DIFF
--- a/bin/shotgun
+++ b/bin/shotgun
@@ -125,11 +125,11 @@ app =
     run Shotgun::Loader.new(config) {
       case env
       when 'development'
-        use Rack::CommonLogger, STDERR  unless server.name =~ /CGI/
+        #use Rack::CommonLogger, STDERR  unless server.name =~ /CGI/
         use Rack::ShowExceptions
         use Rack::Lint
       when 'deployment', 'production'
-        use Rack::CommonLogger, STDERR  unless server.name =~ /CGI/
+        #use Rack::CommonLogger, STDERR  unless server.name =~ /CGI/
       end
     }
   end

--- a/lib/shotgun/loader.rb
+++ b/lib/shotgun/loader.rb
@@ -94,6 +94,7 @@ module Shotgun
       ], @writer)
     ensure
       @writer.close
+      body.close if body.respond_to? :close
       exit! boom ? 1 : 0
     end
 


### PR DESCRIPTION
For example CommonLogger middleware proxies body and only outputs the log message after something has called 'close' on the response body, so without this things like CommonLogger don't work as intended. 