### PR TITLE
Fix the --browse option in ruby >= 1.9

### DIFF
--- a/bin/shotgun
+++ b/bin/shotgun
@@ -60,7 +60,7 @@ opts = OptionParser.new("", 24, '  ') { |opts|
   opts.separator ""
   opts.separator "Shotgun options:"
 
-  opts.on("-O", "--browse", "open browser immediately after starting") { |browse|
+  opts.on("-O", "--browse", "open browser immediately after starting") {
     browse = true
   }
 


### PR DESCRIPTION
In newer rubies, the `browse` parameter shadows the outer variable, which is the one we actually want to set. The parameter wasn't being used, anyway, so I just removed it.

Tested manually in `1.8.7-p371`, `1.9.3-p392`, and `2.0.0-p0`, since there aren't any tests for the `shotgun` binary and I'm not industrious enough to add them right now.
