### PR TITLE
Fix `Rack::CommonLogger` output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /pkg
+/test/verbose.log
 shotgun.1.html

--- a/lib/shotgun/loader.rb
+++ b/lib/shotgun/loader.rb
@@ -86,6 +86,7 @@ module Shotgun
       status, headers, body = assemble_app.call(@env)
       Marshal.dump([:ok, status, headers.to_hash], @writer)
       spec_body(body).each { |chunk| @writer.write(chunk) }
+      body.close if body.respond_to?(:close)
     rescue Object => boom
       Marshal.dump([
         :error,

--- a/test/test_shotgun_loader.rb
+++ b/test/test_shotgun_loader.rb
@@ -32,4 +32,19 @@ class ShotgunLoaderTest < Test::Unit::TestCase
     assert res.body =~ %r|<pre>(?:.{1023}\n){1024}</pre>|,
       "body of size #{res.body.size} does not match expected output"
   end
+
+  def test_logging
+    file = rackup_file('verbose.ru')
+
+    $logger = File.open('test/verbose.log', 'w')
+    $logger.sync = true
+
+    shotgun = Shotgun::Loader.new(file)
+    request = Rack::MockRequest.new(shotgun)
+    request.get('/', 'REMOTE_ADDR' => 'foo.local')
+
+    $logger.close
+
+    assert_match /^foo.local/, File.read('test/verbose.log')
+  end
 end

--- a/test/verbose.ru
+++ b/test/verbose.ru
@@ -1,0 +1,7 @@
+require 'rack'
+
+app = lambda { |env|
+  [200, {'Content-Type'=>'text/plain'}, ['BANG!']] }
+
+use Rack::CommonLogger, $logger
+run app


### PR DESCRIPTION
I hadn't seen #56 but it's the same fix + tests.

Explanation:

`Rack::CommonLogger` wraps the body inside a `Rack::BodyProxy` and only logs once the body is closed. I guess other web servers call `#close` and we didn't.