### PR TITLE
Rack 2.x compat

### DIFF
--- a/bin/shotgun
+++ b/bin/shotgun
@@ -105,12 +105,6 @@ ENV['BROWSER'] ||=
 ENV['RACK_ENV'] = env
 
 require 'rack'
-require 'rack/utils'
-require 'rack/request'
-require 'rack/response'
-require 'rack/lint'
-require 'rack/commonlogger'
-require 'rack/showexceptions'
 
 require 'shotgun'
 


### PR DESCRIPTION
`rack/commonlogger` was renamed to `rack/common_logger` in Rack 2.x, causing Shotgun to be unusable under Rack >= 2.0

But since Rack uses autoload, those requires aren't needed anyways.
