### PR TITLE
Set rack dependency to ~> 1.0

### DIFF
--- a/shotgun.gemspec
+++ b/shotgun.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
-  s.add_dependency 'rack',    '>= 1.0'
+  s.add_dependency 'rack',    '~> 1.0'
 
   s.homepage = "https://github.com/rtomayko/shotgun"
 end


### PR DESCRIPTION
Rack 2.0.1 changes the names of submodules. This will break the lines
that require rack in bin/shotgun. This PR set a pessimistic constraint
on the version of rack, so that the older version with the unchanged
submodule names will be required.

Closes rtomayko/shotgun#62

This is just a quick suggestion. If you fix this issue in another way, feel free to close this one!
