### PR TITLE
Rename rack requires, because they have been renamed during a refactor.

### DIFF
--- a/bin/shotgun
+++ b/bin/shotgun
@@ -109,8 +109,8 @@ require 'rack/utils'
 require 'rack/request'
 require 'rack/response'
 require 'rack/lint'
-require 'rack/commonlogger'
-require 'rack/showexceptions'
+require 'rack/common_logger'
+require 'rack/show_exceptions'
 
 require 'shotgun'
 

--- a/shotgun.gemspec
+++ b/shotgun.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'shotgun'
-  s.version = '0.9.1'
+  s.version = '0.9.2'
 
   s.description = "Reloading Rack development server"
   s.summary     = s.description


### PR DESCRIPTION
Rack renamed commonlogger and showexceptions see commit for more details:
https://github.com/rack/rack/commit/857641dab255dbec490fead1d3a0f1ff999b2137

Resolves https://github.com/rtomayko/shotgun/issues/65
