### PR TITLE
Default host to 'localhost' for ipv4/v6 support

### DIFF
--- a/bin/shotgun
+++ b/bin/shotgun
@@ -3,7 +3,7 @@
 require 'optparse'
 
 env = ENV['RACK_ENV'] || 'development'
-host = ENV['HOST'] || '127.0.0.1'
+host = ENV['HOST'] || 'localhost'
 port = ENV['PORT'] || 9393
 mount_path = "/"
 browse = false


### PR DESCRIPTION
Set the default host to localhost instead of 127.0.0.1 for  simultaneous listening on ipv4 and ipv6
