### PR TITLE
README: Fix an old link to point to Rack on GitHub instead, update man page CHANGELOG, regenerate man page

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Caveats
 Links
 -----
 
-[Shotgun](http://github.com/rtomayko/shotgun)
+[Shotgun](https://github.com/rtomayko/shotgun)
 
-[Rack](http://rack.rubyforge.org/)
+[Rack](https://github.com/rack/rack)
 
-[Sinatra](http://www.sinatrarb.com/)
+[Sinatra](https://www.sinatrarb.com/)
 
 The reloading system in Ian Bicking's webware framework served as inspiration
 for the approach taken in Shotgun. Ian lays down the pros and cons of this

--- a/man/index.txt
+++ b/man/index.txt
@@ -1,6 +1,6 @@
 ruby(1)    http://man.cx/ruby
 
 # other resources
-rack       http://rack.rubyforge.org/doc/README.html
-rack-spec  http://rack.rubyforge.org/doc/SPEC.html
+rack       http://www.rubydoc.info/github/rack/rack/master/file/README.rdoc
+rack-spec  http://www.rubydoc.info/github/rack/rack/master/file/SPEC
 sinatra    http://www.sinatrarb.com/

--- a/man/shotgun.1
+++ b/man/shotgun.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "SHOTGUN" "1" "March 2015" "Shotgun 0.9.1" ""
+.TH "SHOTGUN" "1" "December 2017" "Shotgun 0.9.2" ""
 .
 .SH "NAME"
 \fBshotgun\fR \- reloading rack development server
@@ -10,7 +10,7 @@
 \fBshotgun\fR [\fIoptions\fR] [\fIrackup\-file\fR]
 .
 .SH "DESCRIPTION"
-\fBShotgun\fR is a simple process\-per\-request Rack \fIhttp://rack\.rubyforge\.org/doc/README\.html\fR server designed for use in development environments\. Each time a request is received, \fBshotgun\fR forks, loads the \fIrackup\-file\fR, processes a single request and exits\. The result is application\-wide reloading of all configuration, source files, and templates without the need for complex application\-level reloading logic\.
+\fBShotgun\fR is a simple process\-per\-request Rack \fIhttp://www\.rubydoc\.info/github/rack/rack/master/file/README\.rdoc\fR server designed for use in development environments\. Each time a request is received, \fBshotgun\fR forks, loads the \fIrackup\-file\fR, processes a single request and exits\. The result is application\-wide reloading of all configuration, source files, and templates without the need for complex application\-level reloading logic\.
 .
 .P
 When no \fIrackup\-file\fR is given, \fBshotgun\fR uses the \fBconfig\.ru\fR file in the current working directory\.
@@ -155,6 +155,13 @@ Fork and report issues at github\.com:
 \fBgit clone git://github\.com/rtomayko/shotgun\.git\fR
 .
 .SH "VERSION HISTORY"
+.
+.SS "Version 0\.9\.2 (2016 September 10)"
+.
+.IP "\(bu" 4
+Fixed compatibility with Rack 2\.0 (#61)\.
+.
+.IP "" 0
 .
 .SS "Version 0\.9\.1 (2015 March 1)"
 .

--- a/man/shotgun.1.ronn
+++ b/man/shotgun.1.ronn
@@ -160,6 +160,10 @@ Fork and report issues at github.com:
 
 ## VERSION HISTORY
 
+### Version 0.9.2 (2016 September 10)
+
+ * Fixed compatibility with Rack 2.0 (#61).
+
 ### Version 0.9.1 (2015 March 1)
 
  * Fix a long-standing issue that caused Shotgun not to show any access logs


### PR DESCRIPTION
This PR

- fixes an old hyperlink which pointed at rack on RubyForge (in the man page and in the README)
- amends the changelog section of the man page
- regenerates the man page
