### PR TITLE
Fix ruby 2.7 warnings

### DIFF
--- a/bin/shotgun
+++ b/bin/shotgun
@@ -153,7 +153,7 @@ Shotgun.preload
 
 base_url = "http://#{options[:Host]}:#{options[:Port]}#{mount_path}"
 puts "== Shotgun/#{server.to_s.sub(/Rack::Handler::/, '')} on #{base_url}"
-server.run app, options do |inst|
+server.run app, **options do |inst|
   if browse
     if ENV['BROWSER']
       system "#{ENV['BROWSER']} '#{base_url}'"


### PR DESCRIPTION
On running `shotgun` there was a warning 
`.rvm/gems/ruby-2.7.0/gems/shotgun-0.9.2/bin/shotgun:156: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`
